### PR TITLE
Deprecation Update

### DIFF
--- a/custom_components/plex_webhooks/__init__.py
+++ b/custom_components/plex_webhooks/__init__.py
@@ -9,6 +9,7 @@ import aiohttp
 
 from homeassistant.const import CONF_WEBHOOK_ID
 import homeassistant.helpers.config_validation as cv
+from homeassistant.components import webhook
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,7 +79,7 @@ async def handle_webhook(hass, webhook_id, request):
 async def async_setup(hass, config):
     _LOGGER.debug('Initing Plex Webhooks!')
     webhook_id = config[DOMAIN][CONF_WEBHOOK_ID]
-    hass.components.webhook.async_register(
-        DOMAIN, "Plex", webhook_id, handle_webhook
+    webhook.async_register(
+        hass, DOMAIN, "Plex", webhook_id, handle_webhook
     )
     return True

--- a/custom_components/plex_webhooks/manifest.json
+++ b/custom_components/plex_webhooks/manifest.json
@@ -1,6 +1,7 @@
 {
     "domain": "plex_webhooks",
     "name": "Plex Webhooks",
+	"version": "0.7",
     "documentation": "https://github.com/JBassett/plex_webhooks",
     "dependencies": [
         "webhook"

--- a/custom_components/plex_webhooks/manifest.json
+++ b/custom_components/plex_webhooks/manifest.json
@@ -1,7 +1,7 @@
 {
     "domain": "plex_webhooks",
     "name": "Plex Webhooks",
-	"version": "0.7",
+    "version": "0.7",
     "documentation": "https://github.com/JBassett/plex_webhooks",
     "dependencies": [
         "webhook"

--- a/custom_components/plex_webhooks/manifest.json
+++ b/custom_components/plex_webhooks/manifest.json
@@ -2,12 +2,13 @@
     "domain": "plex_webhooks",
     "name": "Plex Webhooks",
     "version": "0.7",
-    "documentation": "https://github.com/JBassett/plex_webhooks",
+    "documentation": "https://github.com/Abductist/plex_webhooks",
     "dependencies": [
         "webhook"
     ],
     "codeowners": [
-        "@JBassett"
+        "@JBassett",
+        "Abductist"
     ],
     "requirements": []
 }

--- a/custom_components/plex_webhooks/manifest.json
+++ b/custom_components/plex_webhooks/manifest.json
@@ -7,8 +7,8 @@
         "webhook"
     ],
     "codeowners": [
-        "@JBassett",
-        "Abductist"
+        "Abductist",
+        "@JBassett"
     ],
     "requirements": []
 }


### PR DESCRIPTION
Update for the following warning:
Detected that custom integration 'plex_webhooks' accesses hass.components.webhook. This is deprecated and will stop working in Home Assistant 2024.9, it should be updated to import functions used from webhook directly.